### PR TITLE
Taking a stab at adding logger and middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ $ npm install messina
 
 # Setup
 
-* Use [`bunyan`](https://github.com/trentm/node-bunyan) for your app logging.
+```js
+var messina = require('messina');
+var log = messina('myapp');
+
+log.info('Hooray');
+```
+
+* Use `messina` for your app logging. (It's a simple wrapper around [bunyan](https://github.com/trentm/node-bunyan).)
 * Configure Graylog2 to accept GELF messages on some port.
 * Export some environment variables:
 
@@ -28,9 +35,19 @@ $ npm install messina
 
 `GRAYLOG_FACILITY` should be set to the name of your app.
 
-## Recommended
+## Extras
 
-I'm not trying to tell you how to live your life, but I've found that doing the following is pretty useful:
+I'm not trying to tell you how to live your life, but `messina` provides some 
+extra functionality that I've found pretty useful:
+
+```js 
+var messina = require('messina');
+var log = messina('myapp');
+
+log.catchFatal();
+```
+
+is equivalent to
 
 ```js
 process.once('uncaughtException', function (err) {
@@ -42,6 +59,15 @@ process.once('uncaughtException', function (err) {
 I also like to patch `console` so that it outputs to stderr instead of stdout, but I'm a rebel. It's not strictly necessary as `messina` will toss out any messages it can't parse as JSON or that don't look like bunyan log events.
 
 ```js
+var messina = require('messina');
+var log = messina('myapp');
+
+log.patchConsole();
+```
+
+is equivalent to 
+
+```js
 const util = require('util');
 console.log = function() {
   process.stderr.write(util.format.apply(this, arguments) + '\n');
@@ -50,6 +76,8 @@ console.dir = function(object) {
   process.stderr.write(util.inspect(object) + '\n');
 };
 ```
+
+Or you can do both at once with `log.init()`.
 
 # Usage
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const bunyan = require('bunyan');
+const _ = require('underscore');
 const util = require('util');
 
 module.exports = function(opts) {
@@ -9,10 +10,11 @@ module.exports = function(opts) {
     opts = { name: name };
   }
 
-  opts.serializers = {
+  opts.serializers = opts.serializers || {};
+  opts.serializers = _.defaults(opts.serializers, {
     req: bunyan.stdSerializers.req,
     res: bunyan.stdSerializers.res
-  }
+  });
     
   return new Messina(opts);
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,70 @@
+const bunyan = require('bunyan');
+const util = require('util');
+
+module.exports = function(opts) {
+  opts = opts || {};
+
+  if (typeof opts === 'string') {
+    var name = opts;
+    opts = { name: name };
+  }
+
+  opts.serializers = {
+    req: bunyan.stdSerializers.req,
+    res: bunyan.stdSerializers.res
+  }
+    
+  return new Messina(opts);
+};
+
+function Messina(opts) {
+  var self = bunyan.createLogger(opts);
+
+  self.init = function init() {
+    // Patch console so it only outputs to stderr
+    console.log = function() {
+      process.stderr.write(util.format.apply(this, arguments) + '\n');
+    };
+
+    console.dir = function(object) {
+      process.stderr.write(util.inspect(object) + '\n');
+    };
+
+    // Ensure uncaught exceptions end up in the event stream too
+    process.once('uncaughtException', function (err) {
+      self.fatal(err);
+      throw err;
+    });
+  };
+
+  self.middleware = function() {
+    return function (req, res, next) {
+      const startTime = new Date();
+      self.info({
+        req: req
+      }, util.format(
+        'Incoming Request: %s %s',
+        req.method, req.url));
+
+      // this method of hijacking res.end is inspired by connect.logger()
+      // see connect/lib/middleware/logger.js for details
+      const end = res.end;
+      res.end = function(chunk, encoding) {
+        const responseTime = new Date() - startTime;
+        res.end = end;
+        res.end(chunk, encoding);
+        self.info({
+          url: req.url,
+          responseTime: responseTime,
+          res: res,
+        }, util.format(
+          'Outgoing Response: HTTP %s %s (%s ms)',
+          res.statusCode, req.url, responseTime));
+      };
+      return next();
+    };
+  };
+
+  return self;
+};
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "gelf-stream": "~0.2.2",
-    "bunyan": "~0.21.4"
+    "bunyan": "~0.21.4",
+    "underscore": "~1.5.1"
   },
   "devDependencies": {
     "tap": "~0.4.4",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,17 @@
     "messina": "./bin/messina"
   },
   "dependencies": {
-    "gelf-stream": "~0.2.2"
+    "gelf-stream": "~0.2.2",
+    "bunyan": "~0.21.4"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tap": "~0.4.4",
+    "sinon": "~1.7.3",
+    "express": "~3.3.5",
+    "request": "~2.26.0"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/tap test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/bunyan-wrapper.test.js
+++ b/test/bunyan-wrapper.test.js
@@ -51,10 +51,10 @@ test('createLogger', function (t) {
   });
 });
 
-test('init', function(t) {
+test ('patchConsole', function (t) {
   const messina = require('../');
   const log = messina('Apples');
-  log.init();
+  log.patchConsole();
 
   sinon.spy(process.stderr, 'write');
 
@@ -71,7 +71,9 @@ test('init', function(t) {
     process.stderr.write.reset();
     t.end();
   });
+});
 
+test('catchFatal', function (t) {
   t.test('on uncaughtException', function (t) {
     exec('node ' + path.join(__dirname, 'uncaught.js'), {
       cwd: __dirname
@@ -82,5 +84,18 @@ test('init', function(t) {
       t.end();
     });
   });
+});
+
+test('init patches console and catches fatal', function(t) {
+  const messina = require('../');
+  const log = messina('Apples');
+
+  sinon.spy(log, 'patchConsole');
+  sinon.spy(log, 'catchFatal');
+
+  log.init();
+  t.ok(log.patchConsole.calledOnce, 'console patched');
+  t.ok(log.catchFatal.calledOnce, 'fatal will be caught');
+  t.end();
 });
 

--- a/test/bunyan-wrapper.test.js
+++ b/test/bunyan-wrapper.test.js
@@ -1,0 +1,67 @@
+const test = require('tap').test;
+const exec = require('child_process').exec;
+const path = require('path');
+const sinon = require('sinon');
+const bunyan = require('bunyan');
+
+
+test('createLogger', function (t) {
+  const messina = require('../');
+
+  sinon.spy(bunyan, 'createLogger');
+
+  test('wraps bunyan', function(t) {
+    var log = messina({ name: 'Apples' });
+    t.ok(bunyan.createLogger.called, "underlying bunyan method called");
+    bunyan.createLogger.reset();
+    t.end();
+  });
+
+  t.test('string argument', function (t) {
+    var log = messina('Apples');
+    t.ok(bunyan.createLogger.calledWithMatch({ name: 'Apples' }), "string used as name");
+    bunyan.createLogger.reset();
+    t.end();
+  });
+
+  t.test('obj argument', function (t) {
+    var log = messina({name: 'Apples' });
+    t.ok(bunyan.createLogger.calledWithMatch({ name: 'Apples' }), "options object used");
+    bunyan.createLogger.reset();
+    t.end();
+  });
+});
+
+test('init', function(t) {
+  const messina = require('../');
+  const log = messina('Apples');
+  log.init();
+
+  sinon.spy(process.stderr, 'write');
+
+  t.test('patches console.log to stderr', function (t) {
+    console.log('hi');
+    t.ok(process.stderr.write.calledOnce, 'log written to stderr');
+    process.stderr.write.reset();
+    t.end();
+  });
+
+  t.test('patches console.dir to stderr', function (t) {
+    console.dir({ some: 'thing' });
+    t.ok(process.stderr.write.calledOnce, 'log written to stderr');
+    process.stderr.write.reset();
+    t.end();
+  });
+
+  t.test('on uncaughtException', function (t) {
+    exec('node ' + path.join(__dirname, 'uncaught.js'), {
+      cwd: __dirname
+    }, function (error, stdout, stderr) {
+      t.ok(stdout, 'should have stdout');
+      t.doesNotThrow(function(){ JSON.parse(stdout.trim()); }, 'should have JSON on stdout');
+      t.ok(stderr, 'should have stderr');
+      t.end();
+    });
+  });
+});
+

--- a/test/bunyan-wrapper.test.js
+++ b/test/bunyan-wrapper.test.js
@@ -17,7 +17,7 @@ test('createLogger', function (t) {
     t.end();
   });
 
-  t.test('string argument', function (t) {
+  t.test('string argument becomes name', function (t) {
     var log = messina('Apples');
     t.ok(bunyan.createLogger.calledWithMatch({ name: 'Apples' }), "string used as name");
     bunyan.createLogger.reset();
@@ -25,10 +25,29 @@ test('createLogger', function (t) {
   });
 
   t.test('obj argument', function (t) {
-    var log = messina({name: 'Apples' });
-    t.ok(bunyan.createLogger.calledWithMatch({ name: 'Apples' }), "options object used");
-    bunyan.createLogger.reset();
-    t.end();
+    t.test('with name', function (t) {
+      var log = messina({name: 'Apples' });
+      t.ok(bunyan.createLogger.calledWithMatch({ name: 'Apples' }), "options object used");
+      t.equal(log.serializers.req, bunyan.stdSerializers.req, "has default req serializer");
+      t.equal(log.serializers.res, bunyan.stdSerializers.res, "has default res serializer");
+      bunyan.createLogger.reset();
+      t.end();
+    });
+
+    t.test('with serializers', function (t) {
+      var serializer = function(val) { return 'my serializer'; };
+      var log = messina({
+        name: 'Apples',
+        serializers: {
+          foo: serializer,
+          req: serializer
+        }
+      });
+      t.equal(log.serializers.req, serializer, "has my req serializer");
+      t.equal(log.serializers.res, bunyan.stdSerializers.res, "has default res serializer");
+      t.equal(log.serializers.foo, serializer, "has foo serializer");
+      t.end();
+    });
   });
 });
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -12,7 +12,7 @@ test('middleware', function (t) {
 
   sinon.spy(process.stdout, 'write');
 
-  t.test('foo', function (t) {
+  t.test('logs requests and responses', function (t) {
     app.listen(0, function() {
       var server = this;
       request('http://localhost:' + server.address().port, function(err, res) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,0 +1,33 @@
+const test = require('tap').test;
+const express = require('express');
+const request = require('request');
+const sinon = require('sinon');
+
+test('middleware', function (t) {
+  const messina = require('../');
+  const log = messina('Apples');
+
+  const app = express();
+  app.use(log.middleware());
+
+  sinon.spy(process.stdout, 'write');
+
+  t.test('foo', function (t) {
+    app.listen(0, function() {
+      var server = this;
+      request('http://localhost:' + server.address().port, function(err, res) {
+        t.ok(process.stdout.write.calledTwice, "two log statements written");
+
+        var reqLog = JSON.parse(process.stdout.write.getCall(0).args[0]);
+        t.ok(reqLog.req, 'has req');
+
+        var resLog = JSON.parse(process.stdout.write.getCall(1).args[0]);
+        t.ok(resLog.res, 'has res');
+
+        server.close(function(){
+          t.end();    
+        });
+      });
+    });
+  })
+});

--- a/test/uncaught.js
+++ b/test/uncaught.js
@@ -1,3 +1,3 @@
 const messina = require('../');
-var log = messina(' 💣  ').init();
+var log = messina(' 💣  ').catchFatal();
 throw new Error(' 💥i ');

--- a/test/uncaught.js
+++ b/test/uncaught.js
@@ -1,3 +1,3 @@
 const messina = require('../');
 var log = messina(' 💣  ').catchFatal();
-throw new Error(' 💥i ');
+throw new Error(' 💥  ');

--- a/test/uncaught.js
+++ b/test/uncaught.js
@@ -1,0 +1,3 @@
+const messina = require('../');
+var log = messina(' 💣  ').init();
+throw new Error(' 💥i ');


### PR DESCRIPTION
Taking a stab at adding a logger object and middleware to make messina SUPER DUPER CONVENIENT for all our projects. Additional notes inline.

Basic usage is:

``` javascript
var messina = require('messina');
var log = messina('MyAppName');

log.init(); // starts redirecting console to STDERR

app.use(log.middleware()); // for express logging
```
